### PR TITLE
Bump rack from 2.0.3 to 2.0.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     popper_js (1.11.1)
     public_suffix (3.0.0)
     puma (3.10.0)
-    rack (2.0.3)
+    rack (2.0.7)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
     rails (5.1.4)


### PR DESCRIPTION
Bumps rack from 2.0.3 to 2.0.7.

Commits
7fb95db Bumping to 2.0.7 for release
ea57610 Merge pull request #1343 from larsxschneider/ls/forward-fix
1bf2188 Preserve forwarded IP address for trusted proxy chains
cb1fdb6 Merge pull request #1201 from janko-m/make-multipart-parsing-work-for-chunked...
8376dd1 Bumping version for release
313dd6a Whitelist http/https schemes
37c1160 Reduce buffer size to avoid pathological parsing
99fea65 Merge tag '2.0.5' into 2-0-stable
216b7ca Merge pull request #1296 from tomelm/fix-prefers-plaintext
decd976 Bump version for release
Additional commits viewable in compare view